### PR TITLE
Define custom dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This PR activates 🤖  GitHub dependabot automatic updates the GIT submodules. The updates are triggered **weekly on Mondays** (default day).

### 📚  References
- [GitHub dependabot documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates).